### PR TITLE
pdf generation of slides (fixes #28)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ scala:
 jdk:
    - oraclejdk11
 
+env:
+  - NODE_VERSION="12.6.0"
+
+before_install:
+  - nvm install $NODE_VERSION
 
 cache:
    directories:
@@ -15,6 +20,7 @@ cache:
       - $HOME/.m2
       - $HOME/.ivy2/cache
       - $HOME/.coursier
+      - $HOME/.nvm
 
 before_cache:
    - find $HOME/.sbt -name "*.lock" -type f -delete
@@ -24,3 +30,14 @@ before_cache:
 script:
    - sbt ++$TRAVIS_SCALA_VERSION "testOnly *AnswersTest"
    - sbt ++$TRAVIS_SCALA_VERSION tut
+   - make depends
+   - make
+
+deploy:
+   provider: pages
+   local_dir: docs/
+   skip_cleanup: true
+   github_token: $GH_TOKEN
+   on:
+      branch: master
+      condition: $TRAVIS_PULL_REQUEST="false"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+SRCS=$(wildcard docs/*.html)
+PDFS=$(SRCS:.html=.pdf)
+
+pdf: ${PDFS}
+
+docs/%.pdf: docs/%.html
+	decktape $< $@
+
+docs/%.html: slides/tut/%.html
+	sbt tut
+
+depends:
+	npm install -g decktape
+
+clean:
+	rm -rf docs 


### PR DESCRIPTION
Using decktape looks like the best solution for generating pdf from html slides.

Generated pdfs can live in the repo like htmls, but to avoid cluttering it with binary files we could make travis publish them (and maybe also `html`files from tut) to a different branch or repo and only keep sources in master. What option do you prefer?